### PR TITLE
Add option for getting only the file metadata from S3

### DIFF
--- a/app/fly/play/s3/Bucket.scala
+++ b/app/fly/play/s3/Bucket.scala
@@ -55,16 +55,20 @@ case class Bucket(
    *
    * @param itemName	The name of the item you want to retrieve
    */
-  def get(itemName: String): Future[BucketFile] =
-    s3.get(name, Some(itemName), None, None) map S3Response { (status, response) =>
-      val headers = extractHeaders(response)
+  def get(itemName: String, headersOnly: Boolean = false): Future[BucketFile] = {
+    val request = if (headersOnly) s3.head(name, Some(itemName), None, None)
+                  else s3.get(name, Some(itemName), None, None)
+    request map S3Response {
+      (status, response) =>
+        val headers = extractHeaders(response)
 
-      BucketFile(itemName,
-        headers("Content-Type"),
-        response.ahcResponse.getResponseBodyAsBytes,
-        None,
-        Some(headers))
+        BucketFile(itemName,
+          headers("Content-Type"),
+          response.ahcResponse.getResponseBodyAsBytes,
+          None,
+          Some(headers))
     }
+  }
 
   /**
    * Lists the contents of the bucket

--- a/app/fly/play/s3/S3.scala
+++ b/app/fly/play/s3/S3.scala
@@ -132,6 +132,28 @@ class S3(val https: Boolean, val host: String)(implicit val credentials: AwsCred
           delimiter.map("delimiter" -> _).toList): _*)
       .get
 
+
+  /**
+   * Lowlevel method to call get on a bucket or a specific file
+   *
+   * @param bucketName	The name of the bucket
+   * @param path		The path that you want to call the get on, default is "" (empty string).
+   * 					This is mostly used to retrieve single files
+   * @param prefix		A prefix that is most commonly used to list the contents of a 'directory'
+   * @param delimiter	A delimiter that is used to distinguish 'directories'
+   *
+   * @see Bucket.get
+   * @see Bucket.list
+   */
+  def head(bucketName: String, path: Option[String], prefix: Option[String], delimiter: Option[String]): Future[Response] =
+    awsWithSigner
+      .url(httpUrl(bucketName, path.getOrElse("")))
+      .withQueryString(
+        (prefix.map("prefix" -> _).toList :::
+          delimiter.map("delimiter" -> _).toList): _*)
+      .head
+
+
   /**
    * Lowlevel method to call delete on a bucket in order to delete a file
    *


### PR DESCRIPTION
Sometimes it's useful to be able to only check a file metadata without downloading the entire file.